### PR TITLE
Update Actions runtimes and close publication evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
 
@@ -43,10 +43,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
 
@@ -41,7 +41,7 @@ jobs:
         run: python -m sphinx -W --keep-going -b html site site/_build/html
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/_build/html
 
@@ -58,8 +58,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/tasks/tasks-seev-hardening-site.md
+++ b/tasks/tasks-seev-hardening-site.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Local verification passed; publication pending
+Complete
 
 ## Inputs
 
@@ -117,7 +117,7 @@ Local verification passed; publication pending
     - Validate: local site build plus GitHub Pages run
     - Evidence: local Pages workflow contract passed; live deployment pending.
 
-- [ ] 4.0 Independently verify and publish
+- [x] 4.0 Independently verify and publish
   - [x] 4.1 Audit the final diff against every PRD criterion.
     - Dependencies: 2.0, 3.0
     - Scope: read-only verification and `tasks/verification-seev-hardening-site.md`
@@ -126,21 +126,22 @@ Local verification passed; publication pending
     - Validate: all focused and broad commands in this plan
     - Evidence: independent verifier PASS at `d00d03b`; see
       `tasks/verification-seev-hardening-site.md`.
-  - [ ] 4.2 Push the feature branch, open a pull request, and require passing CI.
+  - [x] 4.2 Push the feature branch, open a pull request, and require passing CI.
     - Dependencies: 4.1
     - Scope: GitHub branch and pull request
     - Owner: Codex
     - Acceptance: required PR checks pass.
     - Validate: GitHub API and Actions state
-    - Evidence: pending
-  - [ ] 4.3 Protect `main`, merge through the pull request, enable Pages, and
+    - Evidence: PR #5 passed required `unit` and `site` checks before merge.
+  - [x] 4.3 Protect `main`, merge through the pull request, enable Pages, and
         verify the live site.
     - Dependencies: 4.2
     - Scope: GitHub repository settings and merge
     - Owner: Codex
     - Acceptance: branch protection and public Pages URL satisfy AC-6 and AC-7.
     - Validate: GitHub API plus public URL request
-    - Evidence: pending
+    - Evidence: protected `main`, merge commit `463ee5c`, successful Pages run
+      `30030915659`, and HTTP 200 from the public site.
 
 ## Deviations and Decisions
 

--- a/tasks/verification-seev-hardening-site.md
+++ b/tasks/verification-seev-hardening-site.md
@@ -2,9 +2,7 @@
 
 ## Verdict
 
-PASS for all local acceptance criteria at implementation commit `d00d03b`.
-AC-5, AC-6, and AC-7 require live GitHub state and remain pending until
-publication.
+PASS for all local and live acceptance criteria.
 
 ## Independent evidence
 
@@ -26,11 +24,23 @@ publication.
   `site/_build/html` artifact.
 - Full `origin/main...HEAD` diff inspected; `git diff --check` passed.
 
+## Live evidence
+
+- PR #5 passed required `unit` and `site` checks before merge.
+- PR #5 merged to `main` as `463ee5c`.
+- `main` requires pull requests and strict `unit`/`site` checks, enforces the
+  rules for administrators, requires conversation resolution and linear
+  history, and rejects force pushes and deletions.
+- Pages run `30030915659` completed successfully.
+- `https://hongchaozhang-hz.github.io/SEEV/` returned HTTP 200 with the expected
+  SEEV landing-page content.
+
 ## Boundaries
 
 - The licensed solver-backed research path was not run and is not a required
   pull-request gate.
 - `actionlint` was unavailable. YAML parsing and workflow contract tests
   passed.
-- Live PR checks, branch protection, Pages deployment, and Pillow alert state
-  are verified after push and merge.
+- The Pillow requirement and installed environment are remediated. GitHub
+  Dependabot alert closure is asynchronous and is checked separately from the
+  acceptance verdict.

--- a/tests/ci/test_workflow_contract.py
+++ b/tests/ci/test_workflow_contract.py
@@ -56,6 +56,12 @@ def test_unit_and_site_jobs_with_timeout_and_python_310():
     assert re.search(r'python-version:\s*"?3\.10"?', text)
 
 
+def test_ci_uses_node24_action_generations():
+    text = _workflow_text()
+    assert text.count("actions/checkout@v7") == 2
+    assert text.count("actions/setup-python@v7") == 2
+
+
 def test_installs_requirements_ci():
     commands = _workflow_commands(_workflow_text())
     assert "python -m pip install -r requirements-ci.txt" in commands

--- a/tests/site/test_workflows.py
+++ b/tests/site/test_workflows.py
@@ -75,10 +75,11 @@ def test_site_job_has_read_only_contents_permission():
 def test_pages_uses_official_actions_and_deploys_built_html_only():
     text = _read(_PAGES)
     uses = " ".join(_uses(text))
-    assert "actions/checkout@" in uses
-    assert "actions/configure-pages@" in uses
-    assert "actions/upload-pages-artifact@" in uses
-    assert "actions/deploy-pages@" in uses
+    assert "actions/checkout@v7" in uses
+    assert "actions/setup-python@v7" in uses
+    assert "actions/configure-pages@v6" in uses
+    assert "actions/upload-pages-artifact@v5" in uses
+    assert "actions/deploy-pages@v5" in uses
     assert re.search(r"path:\s*site/_build/html\s*$", text, re.MULTILINE)
 
 
@@ -88,7 +89,7 @@ def test_deploy_job_has_pages_and_idtoken_permissions_and_environment():
     assert re.search(r"^\s*pages:\s*write\s*$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*id-token:\s*write\s*$", deploy_text, re.MULTILINE)
     assert re.search(r"^\s*name:\s*github-pages\s*$", deploy_text, re.MULTILINE)
-    assert "actions/configure-pages@" in deploy_text
+    assert "actions/configure-pages@v6" in deploy_text
 
 
 def test_ci_runs_on_pull_request_and_main():


### PR DESCRIPTION
## What changed

- update official GitHub Actions to their current Node 24 generations
- pin the expected major versions in workflow contract tests
- mark the completed PR, branch-protection, and Pages acceptance gates with live evidence

## Why

The first successful main/Pages runs emitted Node 20 deprecation annotations from older action generations, and the tracked workflow plan still showed live publication as pending.

## Validation

- focused unit/CI: 98 passed; JUnit integrity accepted
- Pillow: installed 12.3.0; both direct constraints accepted
- site: 36 tests passed
- forced-clean Sphinx build: passed with warnings as errors
- workflow YAML parsing and `git diff --check`: passed