### PR TITLE
Correct paper metadata, light theme, and dependency boundaries

### DIFF
--- a/EEV/EEV/Scripts/Search.py
+++ b/EEV/EEV/Scripts/Search.py
@@ -1,7 +1,6 @@
 import sys, os
 import copy
 from numpy import ubyte
-from tomlkit import item
 sys.path.append(os.path.realpath(os.path.dirname(__file__)+"/.."))
 from itertools import combinations
 from collections import deque

--- a/EEV/EEV/Verifier/Verification.py
+++ b/EEV/EEV/Verifier/Verification.py
@@ -1,6 +1,5 @@
 import sys, os
 import time
-from pytest import fail
 sys.path.append(os.path.realpath(os.path.dirname(__file__)+"/.."))
 from Verifier.VeriUtil import *
 from Verifier.LinearVeri import *
@@ -119,6 +118,3 @@ class Verifier(verifier_basic):
             return False, ce_ho
         print('Verification passed!')
         return True, None
-
-    
-    

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ python -m pip install -r requirements-ci.txt
 python -m pytest tests/unit tests/ci -q
 ```
 
-The full research and certification path below requires additional dependencies and a Gurobi license.
+The full research and certification path below uses additional legacy
+dependencies. The focused path does not install them.
 
 ## Requirements
 
@@ -40,11 +41,14 @@ Then, run the following commands:
 
 ```setup
 pip install -r requirements.txt
+pip install -r requirements-legacy.txt
 [Inside EEV] pip install -e .
 [Inside neural_clbf_seev] pip install -e .
 ```
 
-A gurobi license is required.
+Install `requirements-legacy.txt` only when reproducing the historical
+auto_LiRPA search path or the optional Gurobi evaluation backend. The latter
+requires a Gurobi license.
 
 
 Note that the directory `neural_clbf_seev` is adapted from https://github.com/MIT-REALM/neural_clbf. 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # SEEV: Synthesis with Efficient Exact Verification for ReLU Neural Barrier Functions
 
-[![Conference](https://img.shields.io/badge/NeurIPS%20'24-Accepted-success)](https://openreview.net/forum?id=nWMqQHzI3W)
+[![Conference](https://img.shields.io/badge/NeurIPS%20'24-Accepted-success)](https://proceedings.neurips.cc/paper_files/paper/2024/hash/b7868dedad7192f83c9efb042da43317-Abstract-Conference.html)
 
 </div>
 
-This repository contains the implementation of [SEEV (Synthesis with Efficient Exact Verification)](https://openreview.net/forum?id=nWMqQHzI3W), a novel framework for synthesizing Neural Control Barrier Functions (NCBFs) with ReLU activations and performing efficient safety verification. The SEEV approach integrates synthesis and verification to reduce computational overhead while maintaining safety guarantees for autonomous systems. It includes algorithms for training NCBFs with regularization and efficient verification of safety conditions across benchmark systems.
+This repository contains the implementation of [SEEV (Synthesis with Efficient Exact Verification)](https://proceedings.neurips.cc/paper_files/paper/2024/hash/b7868dedad7192f83c9efb042da43317-Abstract-Conference.html), a novel framework for synthesizing Neural Control Barrier Functions (NCBFs) with ReLU activations and performing efficient safety verification. The SEEV approach integrates synthesis and verification to reduce computational overhead while maintaining safety guarantees for autonomous systems. It includes algorithms for training NCBFs with regularization and efficient verification of safety conditions across benchmark systems.
 
 📖 **Documentation:** https://hongchaozhang-hz.github.io/SEEV/ — build locally with `python -m sphinx -W --keep-going -b html site site/_build/html`.
 
@@ -25,7 +25,16 @@ The full research and certification path below requires additional dependencies 
 
 The full research and certification path has been tested for Python 3.9; the focused CI path above targets Python 3.10+.
 
-To install requirements and set up for the project, first, install [auto_LiRPA](https://github.com/Verified-Intelligence/auto_LiRPA) following the project's README.
+The `auto_LiRPA` search integration is inherited from the legacy
+[`exactverif-reluncbf-nips23`](https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23)
+verification path. Gurobi enters through the adapted
+[`neural_clbf`](https://github.com/MIT-REALM/neural_clbf) training stack; it is
+not declared by `exactverif-reluncbf-nips23`. Both are legacy, optional
+integrations outside the focused CI path.
+
+To install requirements and set up for the full legacy path, first install
+[auto_LiRPA](https://github.com/Verified-Intelligence/auto_LiRPA) following the
+project's README.
 
 Then, run the following commands:
 
@@ -53,11 +62,16 @@ To perform certification, run the commands located in `neural_clbf_seev/certify_
 If you find this repository useful in your research, please consider citing:
 
 ```bibtex
-@inproceedings{
-zhang2024seev,
-title={{SEEV}: Synthesis with Efficient Exact Verification for Re{LU} Neural Barrier Functions},
-author={Hongchao Zhang and Zhizhen Qin and Sicun Gao and Andrew Clark},
-booktitle={The Thirty-eighth Annual Conference on Neural Information Processing Systems},
-year={2024},
-url={https://openreview.net/forum?id=nWMqQHzI3W}
+@inproceedings{zhang2024seev,
+    author = {Zhang, Hongchao and Qin, Zhizhen and Gao, Sicun and Clark, Andrew},
+    booktitle = {Advances in Neural Information Processing Systems},
+    doi = {10.52202/079017-3214},
+    editor = {A. Globerson and L. Mackey and D. Belgrave and A. Fan and U. Paquet and J. Tomczak and C. Zhang},
+    pages = {101367--101392},
+    publisher = {Curran Associates, Inc.},
+    title = {SEEV: Synthesis with Efficient Exact Verification for ReLU Neural Barrier Functions},
+    url = {https://proceedings.neurips.cc/paper_files/paper/2024/file/b7868dedad7192f83c9efb042da43317-Paper-Conference.pdf},
+    volume = {37},
+    year = {2024}
 }
+```

--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -1,0 +1,3 @@
+# Optional local performance-test dependencies.
+-r requirements-ci.txt
+pytest-benchmark>=4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,5 +4,4 @@ matplotlib>=3.8.3
 packaging>=24.0
 Pillow>=12.3.0
 pytest>=8.0
-pytest-benchmark>=4.0
 torch>=2.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Optional local development tools.
+-r requirements-ci.txt
+mypy
+flake8
+brunette

--- a/requirements-legacy.txt
+++ b/requirements-legacy.txt
@@ -1,0 +1,6 @@
+# Optional legacy integrations. Do not install these for the focused CI path.
+#
+# auto_LiRPA is inherited from the exactverif-reluncbf-nips23 search code.
+# Gurobi is an optional evaluation backend in the adapted neural_clbf stack.
+auto_LiRPA
+gurobipy==9.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# Legacy research runtime. This file is not the maintained CI environment;
+# use requirements-ci.txt for the supported license-free path.
+
 # Standard
 numpy==1.26.4
 matplotlib==3.8.3
@@ -5,12 +8,6 @@ seaborn==0.13.2
 pandas==2.2.2
 scipy==1.10.1
 scikit-learn==1.2.1
-
-# Code quality
-mypy
-pytest
-flake8
-brunette
 
 # Learning libraries
 torch==1.9.1
@@ -20,14 +17,12 @@ torchmetrics==0.5.1
 # Optimization
 cvxpy==1.2.1
 cvxpylayers==0.1.5
-gurobipy==9.1.2
 osqp
 ecos
 scs
 casadi
 drake
 dreal==4.21.6.2
-tomlkit==0.13.2
 Pillow>=12.3.0
 
 # Geometry

--- a/site/_static/seev.css
+++ b/site/_static/seev.css
@@ -1,18 +1,52 @@
 /*
  * SEEV documentation visual system.
  *
- * Restrained dark theme layered on top of Furo. A single orange accent, thin
- * borders, a compact type scale, a readable content column, and a CSS-only
- * hero texture. No external fonts, images, or generated SVG. Respects
- * prefers-reduced-motion and keeps strong keyboard focus.
+ * Coordinated light and dark themes layered on top of Furo. A restrained
+ * orange accent, thin borders, a compact type scale, a readable content
+ * column, and a CSS-only hero texture. No external fonts, images, or generated
+ * SVG. Respects prefers-color-scheme, prefers-reduced-motion, and strong
+ * keyboard focus.
  */
 
-/* Palette applied to both Furo colour schemes so the site is always dark. */
+/* Warm paper-like light palette. ``auto`` defaults to this palette and follows
+   the operating-system dark preference in the media query below. */
 :root,
 body,
 body[data-theme="light"],
-body[data-theme="dark"],
 body[data-theme="auto"] {
+  --color-background-primary: #f8f7f4;   /* canvas */
+  --color-background-secondary: #ffffff; /* cards, sidebar */
+  --color-background-hover: #f1eee8;
+  --color-background-border: #d9d4cb;    /* thin borders */
+
+  --color-foreground-primary: #24201c;
+  --color-foreground-secondary: #5b534b;
+  --color-foreground-muted: #786f66;
+  --color-foreground-border: #d9d4cb;
+
+  --color-brand-primary: #b54800;
+  --color-brand-content: #a84000;
+
+  --color-sidebar-background: #f3f0eb;
+  --color-sidebar-background-border: #ddd7ce;
+  --color-sidebar-link-text: #514a43;
+  --color-sidebar-link-text--top-level: #24201c;
+  --color-sidebar-item-background--current: #e8e2da;
+  --color-sidebar-item-expander-background--hover: #e8e2da;
+
+  --color-api-background: #ffffff;
+  --color-highlight-on-target: #fff1e8;
+
+  --seev-code-background: #f4f1ec;
+  --seev-control-background: #ffffff;
+  --seev-grid-color: rgba(181, 72, 0, 0.12);
+  --seev-glow-color: rgba(234, 100, 0, 0.14);
+
+  color-scheme: light;
+}
+
+/* Graphite dark palette. */
+body[data-theme="dark"] {
   --color-background-primary: #09090b;   /* canvas */
   --color-background-secondary: #16161a; /* cards, sidebar */
   --color-background-hover: #1c1c22;
@@ -36,7 +70,46 @@ body[data-theme="auto"] {
   --color-api-background: #16161a;
   --color-highlight-on-target: #26262c;
 
+  --seev-code-background: #0f0f13;
+  --seev-control-background: #16161a;
+  --seev-grid-color: rgba(234, 100, 0, 0.10);
+  --seev-glow-color: rgba(234, 100, 0, 0.22);
+
   color-scheme: dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  body[data-theme="auto"] {
+    --color-background-primary: #09090b;
+    --color-background-secondary: #16161a;
+    --color-background-hover: #1c1c22;
+    --color-background-border: #26262c;
+
+    --color-foreground-primary: #ededf0;
+    --color-foreground-secondary: #b6b6bf;
+    --color-foreground-muted: #8a8a94;
+    --color-foreground-border: #26262c;
+
+    --color-brand-primary: #ea6400;
+    --color-brand-content: #ea6400;
+
+    --color-sidebar-background: #0d0d10;
+    --color-sidebar-background-border: #1e1e24;
+    --color-sidebar-link-text: #c7c7cf;
+    --color-sidebar-link-text--top-level: #ededf0;
+    --color-sidebar-item-background--current: #1c1c22;
+    --color-sidebar-item-expander-background--hover: #1c1c22;
+
+    --color-api-background: #16161a;
+    --color-highlight-on-target: #26262c;
+
+    --seev-code-background: #0f0f13;
+    --seev-control-background: #16161a;
+    --seev-grid-color: rgba(234, 100, 0, 0.10);
+    --seev-glow-color: rgba(234, 100, 0, 0.22);
+
+    color-scheme: dark;
+  }
 }
 
 /* Compact, readable body type and a ~820px content column. */
@@ -86,7 +159,7 @@ div.highlight {
   border: 1px solid var(--color-background-border);
   border-left: 3px solid var(--color-brand-primary);
   border-radius: 4px;
-  background: #0f0f13;
+  background: var(--seev-code-background);
 }
 
 div.highlight pre {
@@ -104,7 +177,7 @@ div.highlight pre {
   font-size: 0.72rem;
   font-family: inherit;
   color: var(--color-foreground-secondary);
-  background: #16161a;
+  background: var(--seev-control-background);
   border: 1px solid var(--color-background-border);
   border-radius: 4px;
   cursor: pointer;
@@ -143,8 +216,8 @@ div.highlight pre {
 
 .seev-hero__grid {
   background-image:
-    linear-gradient(to right, rgba(234, 100, 0, 0.10) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(234, 100, 0, 0.10) 1px, transparent 1px);
+    linear-gradient(to right, var(--seev-grid-color) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--seev-grid-color) 1px, transparent 1px);
   background-size: 34px 34px;
   mask-image: radial-gradient(ellipse 70% 80% at 30% 0%, #000 40%, transparent 100%);
   -webkit-mask-image: radial-gradient(ellipse 70% 80% at 30% 0%, #000 40%, transparent 100%);
@@ -153,7 +226,7 @@ div.highlight pre {
 .seev-hero__glow {
   background: radial-gradient(
     ellipse 60% 70% at 80% 10%,
-    rgba(234, 100, 0, 0.22),
+    var(--seev-glow-color),
     transparent 60%
   );
 }

--- a/site/citation.rst
+++ b/site/citation.rst
@@ -2,8 +2,8 @@ Citation
 ========
 
 If you find this repository useful in your research, please consider citing the
-SEEV paper. The paper and its reviews are available on OpenReview:
-https://openreview.net/forum?id=nWMqQHzI3W
+SEEV paper. The official paper record is available in the NeurIPS proceedings:
+https://proceedings.neurips.cc/paper_files/paper/2024/hash/b7868dedad7192f83c9efb042da43317-Abstract-Conference.html
 
 **Paper.** *SEEV: Synthesis with Efficient Exact Verification for ReLU Neural
 Barrier Functions.* Hongchao Zhang, Zhizhen Qin, Sicun Gao, and Andrew Clark.
@@ -15,11 +15,15 @@ BibTeX
 
 .. code-block:: bibtex
 
-   @inproceedings{
-   zhang2024seev,
-   title={{SEEV}: Synthesis with Efficient Exact Verification for Re{LU} Neural Barrier Functions},
-   author={Hongchao Zhang and Zhizhen Qin and Sicun Gao and Andrew Clark},
-   booktitle={The Thirty-eighth Annual Conference on Neural Information Processing Systems},
-   year={2024},
-   url={https://openreview.net/forum?id=nWMqQHzI3W}
+   @inproceedings{zhang2024seev,
+       author = {Zhang, Hongchao and Qin, Zhizhen and Gao, Sicun and Clark, Andrew},
+       booktitle = {Advances in Neural Information Processing Systems},
+       doi = {10.52202/079017-3214},
+       editor = {A. Globerson and L. Mackey and D. Belgrave and A. Fan and U. Paquet and J. Tomczak and C. Zhang},
+       pages = {101367--101392},
+       publisher = {Curran Associates, Inc.},
+       title = {SEEV: Synthesis with Efficient Exact Verification for ReLU Neural Barrier Functions},
+       url = {https://proceedings.neurips.cc/paper_files/paper/2024/file/b7868dedad7192f83c9efb042da43317-Paper-Conference.pdf},
+       volume = {37},
+       year = {2024}
    }

--- a/site/conf.py
+++ b/site/conf.py
@@ -17,7 +17,10 @@ paper_title = (
 # Venue and year, kept verbatim from README.md / the BibTeX entry.
 venue = "The Thirty-eighth Annual Conference on Neural Information Processing Systems"
 year = "2024"
-openreview_url = "https://openreview.net/forum?id=nWMqQHzI3W"
+paper_url = (
+    "https://proceedings.neurips.cc/paper_files/paper/2024/hash/"
+    "b7868dedad7192f83c9efb042da43317-Abstract-Conference.html"
+)
 
 # -- General configuration ---------------------------------------------------
 
@@ -39,12 +42,11 @@ html_js_files = ["copybutton.js"]
 html_show_sourcelink = False
 html_copy_source = False
 
-# Force the restrained dark documentation system regardless of the visitor's
-# OS colour scheme; the palette lives in ``_static/seev.css``.
+# The coordinated light and dark palettes live in ``_static/seev.css``.
 html_theme_options = {
     "light_css_variables": {
-        "color-brand-primary": "#ea6400",
-        "color-brand-content": "#ea6400",
+        "color-brand-primary": "#b54800",
+        "color-brand-content": "#a84000",
     },
     "dark_css_variables": {
         "color-brand-primary": "#ea6400",

--- a/site/getting-started.rst
+++ b/site/getting-started.rst
@@ -34,22 +34,33 @@ Full research / certification path
 .. warning::
 
    The full path is **not** covered by continuous integration. It requires
-   additional, older pinned dependencies (see ``requirements.txt``) and a
-   **Gurobi license**. Reproducing it may require a specific platform and
-   non-trivial resources; results are not re-derived on this site.
+   additional, older pinned dependencies (see ``requirements.txt``).
+   Historical auto_LiRPA search and Gurobi evaluation integrations are
+   isolated in ``requirements-legacy.txt``. Reproducing them may require a
+   specific platform, a Gurobi license, and non-trivial resources; results are
+   not re-derived on this site.
 
 Reproducing the paper's training and exact certification requires:
 
-1. Installing the legacy
-   `auto_LiRPA <https://github.com/Verified-Intelligence/auto_LiRPA>`_
-   integration inherited from
-   `exactverif-reluncbf-nips23
-   <https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_.
-2. Installing the pinned research dependencies:
+1. Installing the pinned research runtime:
 
    .. code-block:: bash
 
       pip install -r requirements.txt
+
+2. Installing the optional legacy integrations only when reproducing the
+   historical auto_LiRPA search or Gurobi evaluation paths:
+
+   .. code-block:: bash
+
+      pip install -r requirements-legacy.txt
+
+   ``auto_LiRPA`` is inherited from
+   `exactverif-reluncbf-nips23
+   <https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_. Gurobi
+   is inherited through the adapted
+   `neural_clbf <https://github.com/MIT-REALM/neural_clbf>`_ stack and requires
+   a valid license.
 
 3. Editable installs of the two in-repository packages:
 
@@ -57,10 +68,6 @@ Reproducing the paper's training and exact certification requires:
 
       cd EEV && pip install -e .
       cd neural_clbf_seev && pip install -e .
-
-4. A valid **Gurobi license** for the optional evaluation backend inherited
-   through the adapted
-   `neural_clbf <https://github.com/MIT-REALM/neural_clbf>`_ stack.
 
 The ``neural_clbf_seev`` directory is adapted from
 `neural_clbf <https://github.com/MIT-REALM/neural_clbf>`_. Once this path is

--- a/site/getting-started.rst
+++ b/site/getting-started.rst
@@ -40,8 +40,11 @@ Full research / certification path
 
 Reproducing the paper's training and exact certification requires:
 
-1. Installing `auto_LiRPA <https://github.com/Verified-Intelligence/auto_LiRPA>`_
-   by following that project's README.
+1. Installing the legacy
+   `auto_LiRPA <https://github.com/Verified-Intelligence/auto_LiRPA>`_
+   integration inherited from
+   `exactverif-reluncbf-nips23
+   <https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_.
 2. Installing the pinned research dependencies:
 
    .. code-block:: bash
@@ -55,7 +58,9 @@ Reproducing the paper's training and exact certification requires:
       cd EEV && pip install -e .
       cd neural_clbf_seev && pip install -e .
 
-4. A valid **Gurobi license**.
+4. A valid **Gurobi license** for the optional evaluation backend inherited
+   through the adapted
+   `neural_clbf <https://github.com/MIT-REALM/neural_clbf>`_ stack.
 
 The ``neural_clbf_seev`` directory is adapted from
 `neural_clbf <https://github.com/MIT-REALM/neural_clbf>`_. Once this path is

--- a/site/index.rst
+++ b/site/index.rst
@@ -15,13 +15,13 @@ SEEV
 
 SEEV is the reference implementation of `SEEV: Synthesis with Efficient Exact
 Verification for ReLU Neural Barrier Functions
-<https://openreview.net/forum?id=nWMqQHzI3W>`_, published at the
+<https://proceedings.neurips.cc/paper_files/paper/2024/hash/b7868dedad7192f83c9efb042da43317-Abstract-Conference.html>`_, published at the
 Thirty-eighth Annual Conference on Neural Information Processing Systems
 (NeurIPS 2024). The framework trains ReLU Neural Control Barrier Functions
 (NCBFs) with verification-aware regularization and then verifies the safety
 conditions exactly by reasoning over the network's activation regions.
 
-- Paper and reviews: https://openreview.net/forum?id=nWMqQHzI3W
+- Paper: https://proceedings.neurips.cc/paper_files/paper/2024/hash/b7868dedad7192f83c9efb042da43317-Abstract-Conference.html
 - Source repository: https://github.com/HongchaoZhang-HZ/SEEV — the ``EEV``
   verification package and the ``neural_clbf_seev`` training/certification
   code.

--- a/site/limitations.rst
+++ b/site/limitations.rst
@@ -8,19 +8,22 @@ any part of it.
 Licensed solvers
 ----------------
 
-The full certification and training path requires a **Gurobi license**
-(``gurobipy`` is pinned in ``requirements.txt``). Without a valid license the
-exact certification example and the paper-scale runs cannot be executed.
+The adapted ``neural_clbf`` training stack includes a Gurobi evaluation
+backend. It is a legacy optional integration and requires a **Gurobi license**.
+The upstream `exactverif-reluncbf-nips23
+<https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_ repository
+does not declare or import Gurobi.
 
 Legacy research dependencies
 ----------------------------
 
 The research path pins older libraries — for example ``torch==1.9.1``,
 ``pytorch-lightning==1.3.4``, ``cvxpy==1.2.1``, and ``dreal==4.21.6.2`` — and
-also depends on an external
-`auto_LiRPA <https://github.com/Verified-Intelligence/auto_LiRPA>`_ setup.
-These pins can conflict with newer toolchains and are separate from the
-license-free ``requirements-ci.txt`` used by the focused path.
+also contains the ``auto_LiRPA`` search integration inherited from
+`exactverif-reluncbf-nips23
+<https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_. These
+legacy dependencies can conflict with newer toolchains and are separate from
+the license-free ``requirements-ci.txt`` used by the focused path.
 
 Pretrained model expectations
 -----------------------------

--- a/site/limitations.rst
+++ b/site/limitations.rst
@@ -9,7 +9,8 @@ Licensed solvers
 ----------------
 
 The adapted ``neural_clbf`` training stack includes a Gurobi evaluation
-backend. It is a legacy optional integration and requires a **Gurobi license**.
+backend. It is isolated in ``requirements-legacy.txt``, is not installed by
+the maintained path, and requires a **Gurobi license**.
 The upstream `exactverif-reluncbf-nips23
 <https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_ repository
 does not declare or import Gurobi.
@@ -21,9 +22,11 @@ The research path pins older libraries — for example ``torch==1.9.1``,
 ``pytorch-lightning==1.3.4``, ``cvxpy==1.2.1``, and ``dreal==4.21.6.2`` — and
 also contains the ``auto_LiRPA`` search integration inherited from
 `exactverif-reluncbf-nips23
-<https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_. These
-legacy dependencies can conflict with newer toolchains and are separate from
-the license-free ``requirements-ci.txt`` used by the focused path.
+<https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_. The
+auto_LiRPA and Gurobi integrations are declared separately in
+``requirements-legacy.txt``. These legacy dependencies can conflict with newer
+toolchains and are separate from the license-free ``requirements-ci.txt`` used
+by the focused path.
 
 Pretrained model expectations
 -----------------------------

--- a/site/overview.rst
+++ b/site/overview.rst
@@ -52,8 +52,13 @@ runs. It covers the core data structures and the license-free portions of the
 verification surface; it does not run paper-scale training or certification.
 
 **Full research / certification path.** Reproducing the paper's training and
-exact certification uses the dependencies pinned in ``requirements.txt``, an
-`auto_LiRPA <https://github.com/Verified-Intelligence/auto_LiRPA>`_ setup,
-editable installs of the ``EEV`` and ``neural_clbf_seev`` packages, and a
-Gurobi license. This path is **not** covered by continuous integration. See
-:doc:`getting-started` and :doc:`limitations` for the requirements and caveats.
+exact certification uses the dependencies pinned in ``requirements.txt``,
+editable installs of the ``EEV`` and ``neural_clbf_seev`` packages, and legacy
+optional integrations. The ``auto_LiRPA`` search integration descends from
+`exactverif-reluncbf-nips23
+<https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_. Gurobi
+enters through the adapted
+`neural_clbf <https://github.com/MIT-REALM/neural_clbf>`_ training stack, not
+the exact-verification repository. This path is **not** covered by continuous
+integration. See :doc:`getting-started` and :doc:`limitations` for the
+requirements and caveats.

--- a/site/overview.rst
+++ b/site/overview.rst
@@ -53,8 +53,9 @@ verification surface; it does not run paper-scale training or certification.
 
 **Full research / certification path.** Reproducing the paper's training and
 exact certification uses the dependencies pinned in ``requirements.txt``,
-editable installs of the ``EEV`` and ``neural_clbf_seev`` packages, and legacy
-optional integrations. The ``auto_LiRPA`` search integration descends from
+editable installs of the ``EEV`` and ``neural_clbf_seev`` packages, and
+optional integrations isolated in ``requirements-legacy.txt``. The
+``auto_LiRPA`` search integration descends from
 `exactverif-reluncbf-nips23
 <https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23>`_. Gurobi
 enters through the adapted

--- a/site/usage.rst
+++ b/site/usage.rst
@@ -28,8 +28,10 @@ a pretrained model from ``neural_clbf_seev/models``. The exact commands live in
    python certify_cbf.py --system_name darboux --cbf_hidden_layers 2 --cbf_hidden_size 256 --model_path models/darboux_2_256.pt
 
 The metrics reported in the paper are written to stdout. This example requires
-the full research / certification path from :doc:`getting-started`, including a
-Gurobi license; it is not part of continuous integration.
+the full research / certification path from :doc:`getting-started`. The
+historical auto_LiRPA search integration is installed separately from
+``requirements-legacy.txt``; the optional Gurobi controller backend is not a
+focused-CI dependency.
 
 Supported system names
 -----------------------
@@ -57,5 +59,6 @@ The seeded training commands, with hyperparameters specified per run, live in
 - ``neural_clbf_seev/linear_satellite_commands.txt``
 - ``neural_clbf_seev/high_o_commands.txt``
 
-Training and certification use the full research path and its licensed-solver
-requirement; see :doc:`limitations`.
+Training and certification use the full research path. Legacy verification and
+licensed-solver extras are isolated from the focused environment; see
+:doc:`limitations`.

--- a/tests/ci/test_dependency_contract.py
+++ b/tests/ci/test_dependency_contract.py
@@ -1,0 +1,85 @@
+"""Dependency-boundary contracts for maintained, optional, and legacy paths."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _lines(name):
+    return {
+        line.strip()
+        for line in (ROOT / name).read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def _normalized_names(name):
+    names = set()
+    for line in _lines(name):
+        if line.startswith("-r "):
+            continue
+        package = line.split(";", 1)[0]
+        for separator in ("==", ">=", "<=", "~=", ">", "<", "["):
+            package = package.split(separator, 1)[0]
+        names.add(package.strip().lower().replace("-", "_"))
+    return names
+
+
+def test_focused_ci_excludes_optional_tooling_and_legacy_integrations():
+    names = _normalized_names("requirements-ci.txt")
+    assert names.isdisjoint(
+        {
+            "auto_lirpa",
+            "brunette",
+            "flake8",
+            "gurobipy",
+            "mypy",
+            "pytest_benchmark",
+            "tomlkit",
+        }
+    )
+
+
+def test_research_runtime_excludes_dev_and_optional_legacy_extras():
+    names = _normalized_names("requirements.txt")
+    assert names.isdisjoint(
+        {
+            "auto_lirpa",
+            "brunette",
+            "flake8",
+            "gurobipy",
+            "mypy",
+            "pytest",
+            "tomlkit",
+        }
+    )
+
+
+def test_legacy_integrations_are_isolated_and_attributed():
+    legacy = _lines("requirements-legacy.txt")
+    assert "auto_LiRPA" in legacy
+    assert "gurobipy==9.1.2" in legacy
+    text = (ROOT / "requirements-legacy.txt").read_text(encoding="utf-8")
+    assert "exactverif-reluncbf-nips23" in text
+    assert "adapted neural_clbf" in text
+
+
+def test_benchmark_and_development_tools_extend_the_focused_environment():
+    benchmark = _lines("requirements-benchmark.txt")
+    development = _lines("requirements-dev.txt")
+    assert "-r requirements-ci.txt" in benchmark
+    assert "pytest-benchmark>=4.0" in benchmark
+    assert "-r requirements-ci.txt" in development
+    assert {"mypy", "flake8", "brunette"}.issubset(development)
+
+
+def test_production_sources_do_not_import_removed_tooling():
+    search = (ROOT / "EEV" / "EEV" / "Scripts" / "Search.py").read_text(
+        encoding="utf-8"
+    )
+    verification = (
+        ROOT / "EEV" / "EEV" / "Verifier" / "Verification.py"
+    ).read_text(encoding="utf-8")
+    assert "from tomlkit import item" not in search
+    assert "from pytest import fail" not in verification

--- a/tests/site/test_site_contract.py
+++ b/tests/site/test_site_contract.py
@@ -91,6 +91,7 @@ def test_getting_started_distinguishes_paths_with_license_warning():
     assert ".. warning::" in text
     assert "Gurobi license" in text
     assert "requirements.txt" in text
+    assert "requirements-legacy.txt" in text
 
 
 def test_usage_has_exact_darboux_certification_example():
@@ -169,3 +170,5 @@ def test_legacy_dependency_provenance_is_explicit():
     assert source in limitations
     assert "not" in limitations.lower()
     assert "Gurobi" in limitations
+    assert "requirements-legacy.txt" in overview
+    assert "requirements-legacy.txt" in limitations

--- a/tests/site/test_site_contract.py
+++ b/tests/site/test_site_contract.py
@@ -3,7 +3,7 @@
 These checks read the ``site/`` sources as text (no Sphinx import required) and
 assert that every required page exists, that the required commands and links are
 present verbatim, that navigation wires every page into the table of contents,
-and that the dark visual system, copy control, responsive rules, and
+and that the two-theme visual system, copy control, responsive rules, and
 reduced-motion handling are all present.
 """
 
@@ -71,7 +71,10 @@ def test_landing_has_three_capability_cards():
 
 def test_landing_has_paper_and_repository_links():
     index = _read("index.rst")
-    assert "https://openreview.net/forum?id=nWMqQHzI3W" in index
+    assert (
+        "https://proceedings.neurips.cc/paper_files/paper/2024/hash/"
+        "b7868dedad7192f83c9efb042da43317-Abstract-Conference.html"
+    ) in index
     assert "https://github.com/HongchaoZhang-HZ/SEEV" in index
 
 
@@ -121,8 +124,48 @@ def test_limitations_covers_required_caveats():
 
 def test_citation_has_exact_bibtex():
     text = _read("citation.rst")
-    assert "@inproceedings{" in text
-    assert "zhang2024seev" in text
-    assert "author={Hongchao Zhang and Zhizhen Qin and Sicun Gao and Andrew Clark}" in text
-    assert "year={2024}" in text
-    assert "url={https://openreview.net/forum?id=nWMqQHzI3W}" in text
+    assert "@inproceedings{zhang2024seev," in text
+    assert (
+        "author = {Zhang, Hongchao and Qin, Zhizhen and Gao, Sicun and "
+        "Clark, Andrew}"
+    ) in text
+    assert "booktitle = {Advances in Neural Information Processing Systems}" in text
+    assert "doi = {10.52202/079017-3214}" in text
+    assert (
+        "editor = {A. Globerson and L. Mackey and D. Belgrave and A. Fan and "
+        "U. Paquet and J. Tomczak and C. Zhang}"
+    ) in text
+    assert "pages = {101367--101392}" in text
+    assert "publisher = {Curran Associates, Inc.}" in text
+    assert (
+        "title = {SEEV: Synthesis with Efficient Exact Verification for ReLU "
+        "Neural Barrier Functions}"
+    ) in text
+    assert "volume = {37}" in text
+    assert "year = {2024}" in text
+    assert (
+        "url = {https://proceedings.neurips.cc/paper_files/paper/2024/file/"
+        "b7868dedad7192f83c9efb042da43317-Paper-Conference.pdf}"
+    ) in text
+
+
+def test_readme_uses_official_proceedings_record_and_bibtex():
+    with open(_README, "r", encoding="utf-8") as handle:
+        readme = handle.read()
+    assert (
+        "https://proceedings.neurips.cc/paper_files/paper/2024/hash/"
+        "b7868dedad7192f83c9efb042da43317-Abstract-Conference.html"
+    ) in readme
+    assert "@inproceedings{zhang2024seev," in readme
+    assert "doi = {10.52202/079017-3214}" in readme
+    assert "openreview.net" not in readme
+
+
+def test_legacy_dependency_provenance_is_explicit():
+    overview = _read("overview.rst")
+    limitations = _read("limitations.rst")
+    source = "https://github.com/HongchaoZhang-HZ/exactverif-reluncbf-nips23"
+    assert source in overview
+    assert source in limitations
+    assert "not" in limitations.lower()
+    assert "Gurobi" in limitations

--- a/tests/site/test_visual_contract.py
+++ b/tests/site/test_visual_contract.py
@@ -1,6 +1,6 @@
 """Contract tests for the SEEV documentation visual and interaction system.
 
-The dark palette, single orange accent, code-block left rule, responsive
+The light/dark palettes, orange accent, code-block left rule, responsive
 layout, and reduced-motion handling live in ``_static/seev.css``. The
 dependency-free copy control lives in ``_static/copybutton.js``. These checks
 assert their presence as text so no browser or bundler is required.
@@ -18,11 +18,18 @@ def _read(name):
         return handle.read()
 
 
-def test_dark_palette_and_single_accent():
+def test_light_and_dark_palettes_with_accessible_accents():
     css = _read("seev.css").lower()
+    assert "#f8f7f4" in css  # light canvas
+    assert "#ffffff" in css  # light cards
+    assert "#b54800" in css  # light accent
     assert "#09090b" in css  # dark canvas
     assert "#16161a" in css  # dark cards
-    assert "#ea6400" in css  # single orange accent
+    assert "#ea6400" in css  # dark accent
+    assert 'body[data-theme="light"]' in css
+    assert 'body[data-theme="dark"]' in css
+    assert 'body[data-theme="auto"]' in css
+    assert "prefers-color-scheme: dark" in css
 
 
 def test_readable_content_width_around_820px():


### PR DESCRIPTION
## Changes
- replace the paper links and BibTeX with the official NeurIPS 2024 record
- repair the light theme while preserving dark mode and responsive behavior
- document the verified legacy provenance of auto_LiRPA and Gurobi
- isolate legacy, benchmark, and development dependencies from focused CI
- remove unused production imports of tomlkit and pytest

## Validation
- fresh Python 3.10 focused install: 103 unit/CI tests passed
- optional benchmark install: 5 performance tests passed
- site contract: 38 tests passed
- Sphinx: forced clean build with warnings as errors
- workflow YAML and git diff checks passed
- browser checks: light/dark desktop, light mobile, citation/source links, no horizontal overflow