### PR TITLE
Fix dark canvas and move section navigation into sidebar

### DIFF
--- a/site/_static/seev.css
+++ b/site/_static/seev.css
@@ -45,6 +45,17 @@ body[data-theme="auto"] {
   color-scheme: light;
 }
 
+/* Keep the browser canvas in sync with Furo's body-level theme. Without this,
+   the root canvas stays light and can show below the dark page while scrolling. */
+html {
+  background: #f8f7f4;
+}
+
+html:has(body[data-theme="dark"]) {
+  background: #09090b;
+  color-scheme: dark;
+}
+
 /* Graphite dark palette. */
 body[data-theme="dark"] {
   --color-background-primary: #09090b;   /* canvas */
@@ -79,6 +90,11 @@ body[data-theme="dark"] {
 }
 
 @media (prefers-color-scheme: dark) {
+  html:has(body[data-theme="auto"]) {
+    background: #09090b;
+    color-scheme: dark;
+  }
+
   body[data-theme="auto"] {
     --color-background-primary: #09090b;
     --color-background-secondary: #16161a;
@@ -116,11 +132,72 @@ body[data-theme="dark"] {
 body {
   font-size: 0.94rem;
   line-height: 1.65;
+  min-height: 100vh;
+  background: var(--color-background-primary);
 }
 
 article[role="main"] {
   max-width: 820px;
   margin-inline: auto;
+}
+
+/* --- Navigation: one contextual table of contents in the left pane ------- */
+.toc-drawer {
+  display: none;
+}
+
+.sidebar-tree .toctree-l1 > a[aria-expanded] {
+  position: relative;
+  padding-right: 1.5rem;
+}
+
+.sidebar-tree .toctree-l1 > a[aria-expanded]::after {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  content: "›";
+  color: var(--color-foreground-muted);
+  transform: translateY(-50%);
+  transition: transform 0.15s ease;
+}
+
+.sidebar-tree .toctree-l1 > a[aria-expanded="true"]::after {
+  transform: translateY(-50%) rotate(90deg);
+}
+
+.sidebar-tree .toctree-l1 > .seev-page-sections {
+  margin: 0.25rem 0 0.65rem;
+  padding: 0 0 0 0.8rem;
+  border-left: 1px solid var(--color-sidebar-background-border);
+}
+
+.sidebar-tree .seev-page-sections[hidden] {
+  display: none;
+}
+
+.sidebar-tree .seev-page-sections li {
+  margin: 0.12rem 0;
+}
+
+.sidebar-tree .seev-page-sections a {
+  display: block;
+  padding: 0.28rem 0.55rem;
+  border-radius: 4px;
+  color: var(--color-sidebar-link-text);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  text-decoration: none;
+}
+
+.sidebar-tree .seev-page-sections a:hover {
+  color: var(--color-brand-primary);
+  background: var(--color-sidebar-item-expander-background--hover);
+}
+
+.sidebar-tree .seev-page-sections a.current-section {
+  color: var(--color-brand-primary);
+  background: var(--color-sidebar-item-background--current);
+  box-shadow: inset 2px 0 var(--color-brand-primary);
 }
 
 /* Restrained heading scale; avoid oversized headings. */

--- a/site/_static/sidebar-scrollspy.js
+++ b/site/_static/sidebar-scrollspy.js
@@ -1,0 +1,132 @@
+(function () {
+  "use strict";
+
+  const pages = {
+    "overview.html": [
+      ["repository-map", "Repository map"],
+      ["maintained-path-vs-research-path", "Maintained path vs. research path"],
+    ],
+    "method.html": [
+      ["from-trained-network-to-certificate", "From trained network to certificate"],
+      ["limitations-of-the-method", "Limitations of the method"],
+    ],
+    "getting-started.html": [
+      ["focused-ci-path-python-3-10", "Focused CI path (Python 3.10+)"],
+      ["full-research-certification-path", "Full research / certification path"],
+    ],
+    "usage.html": [
+      ["focused-test-gate", "Focused test gate"],
+      ["certification-example-darboux", "Certification example (Darboux)"],
+      ["supported-system-names", "Supported system names"],
+      ["training-command-files", "Training command files"],
+    ],
+    "limitations.html": [
+      ["licensed-solvers", "Licensed solvers"],
+      ["legacy-research-dependencies", "Legacy research dependencies"],
+      ["pretrained-model-expectations", "Pretrained model expectations"],
+      ["no-paper-scale-ci", "No paper-scale CI"],
+      ["platform-and-resource-caveats", "Platform and resource caveats"],
+    ],
+    "citation.html": [["bibtex", "BibTeX"]],
+  };
+
+  function pageName(href) {
+    const url = new URL(href, window.location.href);
+    return url.pathname.split("/").pop() || "index.html";
+  }
+
+  function buildSectionTree(page, sections) {
+    const list = document.createElement("ul");
+    list.className = "seev-page-sections";
+    list.hidden = true;
+    list.setAttribute("aria-label", `Sections in ${page}`);
+
+    for (const [id, label] of sections) {
+      const item = document.createElement("li");
+      const link = document.createElement("a");
+      link.href = `${page}#${id}`;
+      link.textContent = label;
+      link.dataset.sectionId = id;
+      item.appendChild(link);
+      list.appendChild(item);
+    }
+    return list;
+  }
+
+  function installNavigation() {
+    const sidebar = document.querySelector(".sidebar-tree");
+    if (!sidebar) return;
+
+    let activeLinks = [];
+    for (const pageLink of sidebar.querySelectorAll(".toctree-l1 > a")) {
+      const page = pageName(pageLink.href);
+      const sections = pages[page];
+      if (!sections) continue;
+
+      const item = pageLink.closest(".toctree-l1");
+      const tree = buildSectionTree(page, sections);
+      item.appendChild(tree);
+
+      if (item.classList.contains("current-page")) {
+        tree.hidden = false;
+        pageLink.setAttribute("aria-expanded", "true");
+        activeLinks = Array.from(tree.querySelectorAll("a"));
+      } else {
+        pageLink.setAttribute("aria-expanded", "false");
+      }
+    }
+
+    if (!activeLinks.length) return;
+
+    let framePending = false;
+    const updateCurrentSection = function () {
+      framePending = false;
+      const candidates = activeLinks
+        .map((link) => ({
+          link,
+          section: document.getElementById(link.dataset.sectionId),
+        }))
+        .filter(({ section }) => section);
+
+      let current = null;
+      for (const candidate of candidates) {
+        if (candidate.section.getBoundingClientRect().top <= 160) {
+          current = candidate;
+        }
+      }
+      if (
+        candidates.length &&
+        window.scrollY + window.innerHeight >=
+          document.documentElement.scrollHeight - 2
+      ) {
+        current = candidates[candidates.length - 1];
+      }
+
+      for (const candidate of candidates) {
+        const isCurrent = candidate === current;
+        candidate.link.classList.toggle("current-section", isCurrent);
+        if (isCurrent) {
+          candidate.link.setAttribute("aria-current", "location");
+        } else {
+          candidate.link.removeAttribute("aria-current");
+        }
+      }
+    };
+
+    const scheduleUpdate = function () {
+      if (framePending) return;
+      framePending = true;
+      window.requestAnimationFrame(updateCurrentSection);
+    };
+
+    window.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("hashchange", scheduleUpdate);
+    scheduleUpdate();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", installNavigation);
+  } else {
+    installNavigation();
+  }
+})();

--- a/site/conf.py
+++ b/site/conf.py
@@ -38,7 +38,7 @@ html_theme = "furo"
 html_title = "SEEV"
 html_static_path = ["_static"]
 html_css_files = ["seev.css"]
-html_js_files = ["copybutton.js"]
+html_js_files = ["copybutton.js", "sidebar-scrollspy.js"]
 html_show_sourcelink = False
 html_copy_source = False
 

--- a/site/index.rst
+++ b/site/index.rst
@@ -72,6 +72,7 @@ What SEEV provides
 .. toctree::
    :maxdepth: 2
    :caption: Documentation
+   :hidden:
 
    overview
    method

--- a/tests/site/test_site_contract.py
+++ b/tests/site/test_site_contract.py
@@ -43,13 +43,16 @@ def test_conf_uses_furo_and_registers_local_assets():
     assert 'html_theme = "furo"' in conf
     assert '"seev.css"' in conf
     assert '"copybutton.js"' in conf
+    assert '"sidebar-scrollspy.js"' in conf
     assert os.path.isfile(os.path.join(_STATIC, "seev.css"))
     assert os.path.isfile(os.path.join(_STATIC, "copybutton.js"))
+    assert os.path.isfile(os.path.join(_STATIC, "sidebar-scrollspy.js"))
 
 
 def test_navigation_lists_every_page():
     index = _read("index.rst")
     assert ".. toctree::" in index
+    assert ":hidden:" in index
     for name in _PAGES:
         if name == "index.rst":
             continue

--- a/tests/site/test_visual_contract.py
+++ b/tests/site/test_visual_contract.py
@@ -30,6 +30,7 @@ def test_light_and_dark_palettes_with_accessible_accents():
     assert 'body[data-theme="dark"]' in css
     assert 'body[data-theme="auto"]' in css
     assert "prefers-color-scheme: dark" in css
+    assert 'html:has(body[data-theme="dark"])' in css
 
 
 def test_readable_content_width_around_820px():
@@ -70,5 +71,19 @@ def test_copy_control_is_accessible_and_dependency_free():
     assert "aria-label" in js
     assert "clipboard" in js.lower()
     # Keep the control dependency-free: no imports or external URLs.
+    assert "import " not in js
+    assert "http://" not in js and "https://" not in js
+
+
+def test_left_sidebar_scrollspy_is_accessible_and_dependency_free():
+    css = _read("seev.css")
+    js = _read("sidebar-scrollspy.js")
+    assert ".toc-drawer" in css
+    assert "display: none" in css
+    assert "seev-page-sections" in js
+    assert "current-page" in js
+    assert "aria-current" in js
+    assert "aria-expanded" in js
+    assert 'addEventListener("scroll"' in js
     assert "import " not in js
     assert "http://" not in js and "https://" not in js


### PR DESCRIPTION
## Changes
- keep the root browser canvas aligned with Furo's dark and auto themes
- hide the duplicated Documentation list from the landing-page body
- move page sections into the left navigation
- expand only the current page and highlight its active section while scrolling
- remove the redundant right-side table of contents

## Validation
- 142 unit, CI, and site tests passed
- Sphinx forced-clean build passed with warnings as errors
- JavaScript syntax, workflow YAML, and diff checks passed
- browser checks passed for dark/light themes, bottom-of-page rendering, active-section scrolling, page-to-page collapse, and mobile overflow